### PR TITLE
Add sagemaker provider

### DIFF
--- a/examples/transformers_text_classification/requirements.txt
+++ b/examples/transformers_text_classification/requirements.txt
@@ -1,4 +1,3 @@
-accelerate >= 0.12.0
 datasets >= 1.8.0
 sentencepiece != 0.1.92
 scipy
@@ -6,4 +5,4 @@ scikit-learn
 protobuf
 torch >= 1.3
 evaluate
-transformers == 4.26.0
+transformers

--- a/examples/transformers_text_classification/run_glue.py
+++ b/examples/transformers_text_classification/run_glue.py
@@ -43,14 +43,9 @@ from transformers import (
     set_seed,
 )
 from transformers.trainer_utils import get_last_checkpoint
-from transformers.utils import check_min_version, send_example_telemetry
+from transformers.utils import check_min_version
 from transformers.utils.versions import require_version
 
-
-# Will error if the minimal version of Transformers is not installed. Remove at your own risks.
-check_min_version("4.26.0")
-
-require_version("datasets>=1.8.0", "To fix: pip install -r examples/pytorch/text-classification/requirements.txt")
 
 task_to_keys = {
     "cola": ("sentence", None),
@@ -215,10 +210,6 @@ def main():
         model_args, data_args, training_args = parser.parse_json_file(json_file=os.path.abspath(sys.argv[1]))
     else:
         model_args, data_args, training_args = parser.parse_args_into_dataclasses()
-
-    # Sending telemetry. Tracking the example usage helps us better allocate resources to maintain them. The
-    # information sent is the one passed as arguments along with your Python/PyTorch versions.
-    send_example_telemetry("run_glue", model_args, data_args)
 
     # Setup logging
     logging.basicConfig(

--- a/examples/transformers_text_classification/run_glue.py
+++ b/examples/transformers_text_classification/run_glue.py
@@ -24,11 +24,10 @@ from dataclasses import dataclass, field
 from typing import Optional
 
 import datasets
-import numpy as np
-from datasets import load_dataset
-
 import evaluate
+import numpy as np
 import transformers
+from datasets import load_dataset
 from transformers import (
     AutoConfig,
     AutoModelForSequenceClassification,

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ requirements = [
 ]
 extras = {}
 extras["azureml"] = ["azureml-core"]
+extras["sagemaker"] = ["sagemaker"]
 
 setup(
     name="fuego",

--- a/src/fuego/interface.py
+++ b/src/fuego/interface.py
@@ -7,6 +7,7 @@ import fire
 from .provider_azml import AzureMLProvider
 from .provider_sagemaker import SagemakerProvider
 
+
 # TODO - something like a registry w/ all available providers
 providers = {
     "azureml": AzureMLProvider,

--- a/src/fuego/interface.py
+++ b/src/fuego/interface.py
@@ -5,11 +5,12 @@ from typing import Optional
 import fire
 
 from .provider_azml import AzureMLProvider
-
+from .provider_sagemaker import SagemakerProvider
 
 # TODO - something like a registry w/ all available providers
 providers = {
     "azureml": AzureMLProvider,
+    "sagemaker": SagemakerProvider,
 }
 
 

--- a/src/fuego/provider_sagemaker.py
+++ b/src/fuego/provider_sagemaker.py
@@ -1,0 +1,94 @@
+import os
+from pathlib import Path
+from typing import Optional
+
+from .provider_utils import Provider
+from .runtime import is_sagemaker_available
+
+
+if is_sagemaker_available():
+    import sagemaker
+    from sagemaker.huggingface import HuggingFace
+
+
+# TODO - add a ton more of these, more options for cpu, gpu, etc.
+SAGEMAKER_COMPUTE_TARGETS_MAP = {
+    "cpu": "ml.m5.large",
+    "K80": "ml.p2.xlarge",
+}
+
+
+class SagemakerProvider(Provider):
+    # TODO - rethink init logic for providers so signature here is always the same.
+    # Maybe we automate configuration process across clouds and save/load from some cache file?
+    def __init__(
+        self,
+        arn=None,
+    ):
+        if not is_sagemaker_available():
+            raise ImportError("Sagemaker is not available. Please install it with `pip install fuego[sagemaker]`")
+
+        arn = arn or os.environ.get("SAGEMAKER_ROLE_ARN")
+        try:
+            role = arn or sagemaker.get_execution_role()
+        except ValueError:
+            # TODO - maybe auth with boto3 here via role name?
+            if arn is None:
+                raise RuntimeError(
+                    "Could not determine sagemaker execution role automatically.\n\nThis probably means you're running this script outside of a Sagemaker Studio Notebook.\n"
+                    "To resolve this issue, please provide a valid ARN to the --role flag or set it as the SAGEMAKER_ROLE_ARN environment variable."
+                )
+
+        self.role = role
+
+    def create_run(
+        self,
+        script: str,
+        instance_name: str,  # NOTE: instance_name not used in sagemaker...should probably remove from base.
+        instance_type: str,
+        instance_count: int = 1,
+        requirements_file: Optional[str] = None,
+        # Sagemaker Specific.
+        image_uri: str = "763104351884.dkr.ecr.us-east-2.amazonaws.com/huggingface-pytorch-training:1.10.2-transformers4.17.0-gpu-py38-cu113-ubuntu20.04",
+        py_version: str = "py38",
+        # Script Args
+        **kwargs,
+    ):
+        """Submits a run on a compute target. Returns run info"""
+
+        sagemaker_instance_type = SAGEMAKER_COMPUTE_TARGETS_MAP.get(instance_type)
+        if not sagemaker_instance_type:
+            raise ValueError(
+                f"Invalid instance type {instance_type}, must be one of {list(SAGEMAKER_COMPUTE_TARGETS_MAP)}"
+            )
+
+        huggingface_estimator = HuggingFace(
+            entry_point=Path(script).name,
+            source_dir=str(Path(script).parent),
+            instance_type=sagemaker_instance_type,
+            instance_count=instance_count,
+            role=self.role,
+            py_version=py_version,
+            image_uri=image_uri,
+            hyperparameters=kwargs,
+            dependencies=[str(requirements_file)] if requirements_file else None,
+        )
+
+        huggingface_estimator.fit(wait=True)
+
+    def list_runs(self, experiment_name=None, **kwargs):  # TODO- proper args
+        raise NotImplementedError
+
+    def create_compute_target(
+        self,
+        name,
+        instance_type,
+    ):
+        """Not applicable for Sagemaker...should update base provider"""
+        raise NotImplementedError
+
+    def list_compute_targets(self, **kwargs):
+        raise NotImplementedError
+
+    def delete_compute_target(self, name, **kwargs):
+        raise NotImplementedError

--- a/src/fuego/runtime.py
+++ b/src/fuego/runtime.py
@@ -51,8 +51,10 @@ def is_azureml_available() -> bool:
 def get_azureml_version() -> str:
     return _get_version("azureml-core")
 
+
 def is_sagemaker_available() -> bool:
     return _is_available("sagemaker")
+
 
 def get_sagemaker_version() -> str:
     return _get_version("sagemaker")

--- a/src/fuego/runtime.py
+++ b/src/fuego/runtime.py
@@ -16,6 +16,7 @@ _package_versions = {}
 
 _CANDIDATES = {
     "azureml-core": {"azureml-core"},
+    "sagemaker": {"sagemaker"},
 }
 
 # Check once at runtime
@@ -49,3 +50,9 @@ def is_azureml_available() -> bool:
 
 def get_azureml_version() -> str:
     return _get_version("azureml-core")
+
+def is_sagemaker_available() -> bool:
+    return _is_available("sagemaker")
+
+def get_sagemaker_version() -> str:
+    return _get_version("sagemaker")


### PR DESCRIPTION
Adds a very primitive sagemaker provider. Some todos/notes which I'll either take care of here or in future PR...

- `instance_name` is not used in sagemaker, but was part of the base provider's `create_run` fn. Do we want to keep it in the base, or can we remove?
- Only have a couple instances in the instance mapping rn...should add a few more equivalent w/ azureml instances
- environment creation is quite confusing here...the sdk wouldn't let me pick anything higher than py36, but I was able to get py38 by using a call to `sagemaker.image_uris.get_training_image_uri` and passing an `image_uri` directly instead of framework/torch versions directly.

```python
from sagemaker import image_uris
image_uris.get_training_image_uri(
    framework='huggingface',
    region='us-east-2',
    framework_version='4.17.0',
    pytorch_version='1.10.2',
    instance_type='ml.p2.xlarge'
)
# returns the below image_uri, which I've hard coded for now...
# '763104351884.dkr.ecr.us-east-2.amazonaws.com/huggingface-pytorch-training:1.10.2-transformers4.17.0-gpu-py38-cu113-ubuntu20.04'
```