### PR TITLE
🔒 Pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -13,9 +13,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@e9aba2c848f5ebd159c070c61ea2c4e2b122355e  # v2
         with:
           python-version: "3.x"
       - name: Install dependencies

--- a/.github/workflows/sync-with-huggingface.yml
+++ b/.github/workflows/sync-with-huggingface.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Sync with Hugging Face
-      uses: nateraw/huggingface-sync-action@v0.0.4
+      uses: nateraw/huggingface-sync-action@c1518d9edf69c7e6beaa8f0c35df06d5952e2cf0  # v0.0.4
       with:
         github_repo_id: huggingface/fuego
         huggingface_repo_id: nateraw/fuego


### PR DESCRIPTION
## 🔒 Pin GitHub Actions to commit SHAs

This PR pins all GitHub Actions to their exact commit SHA instead of mutable tags or branch names.

**Why?**
Pinning to a SHA prevents supply chain attacks where a tag (e.g. `v4`) could be moved to point to malicious code.

### Changes

| Workflow | Action | Avant | Après | SHA |
|---|---|---|---|---|
| `python-publish.yml` | `actions/checkout` | `v2` | `v6.0.2` | `de0fac2e4500…` |
| `python-publish.yml` | `actions/setup-python` | `v2` | `v2` | `e9aba2c848f5…` |
| `sync-with-huggingface.yml` | `nateraw/huggingface-sync-action` | `v0.0.4` | `v0.0.4` | `c1518d9edf69…` |

> 🤖 Generated by `/github-actions-audit` — [security/pin-actions-to-sha]


Closes huggingface/tracking-issues#112